### PR TITLE
dogfood

### DIFF
--- a/.github/workflows/pypi-publish-with-poetry.yml
+++ b/.github/workflows/pypi-publish-with-poetry.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: 3.9
 
       - name: Publish to pypi
-        uses: ./action.yml
+        uses: .
         with:
           project-name: pypi-publish-with-poetry-dogfood
           pypi-token: ${{ secrets.PYPI_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
           python-version: 3.9
 
       - name: Publish to pypi
-        uses: ./action.yml
+        uses: .
         with:
           project-name: pypi-publish-with-poetry-dogfood
           pypi-token: ${{ secrets.PYPI_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
           python-version: 3.9
 
       - name: Publish to pypi
-        uses: ./action.yml
+        uses: .
         with:
           project-name: pypi-publish-with-poetry-dogfood
           pypi-token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pypi-publish-with-poetry.yml
+++ b/.github/workflows/pypi-publish-with-poetry.yml
@@ -60,24 +60,24 @@ jobs:
           dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
           pyproject-folder: ./pypi-publish-with-poetry-dogfood
 
-  dogfood-mac:
-    needs: dogfood-windows
-    runs-on: macos-11
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Setup python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-      - name: Publish to pypi
-        uses: ./
-        with:
-          project-name: pypi-publish-with-poetry-dogfood
-          pypi-token: ${{ secrets.PYPI_TOKEN_DOGFOOD }}
-          pre-release: ${{ github.ref != 'refs/heads/main' }}
-          dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
-          pyproject-folder: ./pypi-publish-with-poetry-dogfood
+#  dogfood-mac:
+#    needs: dogfood-windows
+#    runs-on: macos-11
+#
+#    steps:
+#      - name: Checkout repository
+#        uses: actions/checkout@v2
+#
+#      - name: Setup python 3.9
+#        uses: actions/setup-python@v2
+#        with:
+#          python-version: 3.9
+#
+#      - name: Publish to pypi
+#        uses: ./
+#        with:
+#          project-name: pypi-publish-with-poetry-dogfood
+#          pypi-token: ${{ secrets.PYPI_TOKEN_DOGFOOD }}
+#          pre-release: ${{ github.ref != 'refs/heads/main' }}
+#          dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
+#          pyproject-folder: ./pypi-publish-with-poetry-dogfood

--- a/.github/workflows/pypi-publish-with-poetry.yml
+++ b/.github/workflows/pypi-publish-with-poetry.yml
@@ -1,4 +1,4 @@
-name: pypi-publish-with-poetry-dogfood
+name: dogfood
 
 on:
   push:

--- a/.github/workflows/pypi-publish-with-poetry.yml
+++ b/.github/workflows/pypi-publish-with-poetry.yml
@@ -33,7 +33,7 @@ jobs:
         uses: ./
         with:
           project-name: pypi-publish-with-poetry-dogfood
-          pypi-token: ${{ secrets.PYPI_TOKEN }}
+          pypi-token: ${{ secrets.PYPI_TOKEN_DOGFOOD }}
           pre-release: ${{ github.ref != 'refs/heads/main' }}
           dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
           pyproject-folder: ./pypi-publish-with-poetry-dogfood

--- a/.github/workflows/pypi-publish-with-poetry.yml
+++ b/.github/workflows/pypi-publish-with-poetry.yml
@@ -55,7 +55,7 @@ jobs:
         uses: ./
         with:
           project-name: pypi-publish-with-poetry-dogfood
-          pypi-token: ${{ secrets.PYPI_TOKEN }}
+          pypi-token: ${{ secrets.PYPI_TOKEN_DOGFOOD }}
           pre-release: ${{ github.ref != 'refs/heads/main' }}
           dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
           pyproject-folder: ./pypi-publish-with-poetry-dogfood
@@ -77,7 +77,7 @@ jobs:
         uses: ./
         with:
           project-name: pypi-publish-with-poetry-dogfood
-          pypi-token: ${{ secrets.PYPI_TOKEN }}
+          pypi-token: ${{ secrets.PYPI_TOKEN_DOGFOOD }}
           pre-release: ${{ github.ref != 'refs/heads/main' }}
           dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
           pyproject-folder: ./pypi-publish-with-poetry-dogfood

--- a/.github/workflows/pypi-publish-with-poetry.yml
+++ b/.github/workflows/pypi-publish-with-poetry.yml
@@ -1,0 +1,83 @@
+name: pypi-publish-with-poetry-dogfood
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+  workflow_dispatch:
+    inputs:
+      deploy_branch:
+        description: The main branch is always deployed. To deploy from another branch, input something in the box below.
+        required: false
+        default: ''
+
+
+jobs:
+  dogfood-linux:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Publish to pypi
+        uses: ./action.yml
+        with:
+          project-name: pypi-publish-with-poetry-dogfood
+          pypi-token: ${{ secrets.PYPI_TOKEN }}
+          pre-release: ${{ github.ref != 'refs/heads/main' }}
+          dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
+          pyproject-folder: ./pypi-publish-with-poetry-dogfood
+
+  dogfood-windows:
+    needs: dogfood-linux
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Publish to pypi
+        uses: ./action.yml
+        with:
+          project-name: pypi-publish-with-poetry-dogfood
+          pypi-token: ${{ secrets.PYPI_TOKEN }}
+          pre-release: ${{ github.ref != 'refs/heads/main' }}
+          dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
+          pyproject-folder: ./pypi-publish-with-poetry-dogfood
+
+  dogfood-mac:
+    needs: dogfood-windows
+    runs-on: macos-11
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Publish to pypi
+        uses: ./action.yml
+        with:
+          project-name: pypi-publish-with-poetry-dogfood
+          pypi-token: ${{ secrets.PYPI_TOKEN }}
+          pre-release: ${{ github.ref != 'refs/heads/main' }}
+          dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
+          pyproject-folder: ./pypi-publish-with-poetry-dogfood

--- a/.github/workflows/pypi-publish-with-poetry.yml
+++ b/.github/workflows/pypi-publish-with-poetry.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: 3.9
 
       - name: Publish to pypi
-        uses: .
+        uses: ./
         with:
           project-name: pypi-publish-with-poetry-dogfood
           pypi-token: ${{ secrets.PYPI_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
           python-version: 3.9
 
       - name: Publish to pypi
-        uses: .
+        uses: ./
         with:
           project-name: pypi-publish-with-poetry-dogfood
           pypi-token: ${{ secrets.PYPI_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
           python-version: 3.9
 
       - name: Publish to pypi
-        uses: .
+        uses: ./
         with:
           project-name: pypi-publish-with-poetry-dogfood
           pypi-token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pypi-publish-with-poetry.yml
+++ b/.github/workflows/pypi-publish-with-poetry.yml
@@ -60,24 +60,24 @@ jobs:
           dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
           pyproject-folder: ./pypi-publish-with-poetry-dogfood
 
-#  dogfood-mac:
-#    needs: dogfood-windows
-#    runs-on: macos-11
-#
-#    steps:
-#      - name: Checkout repository
-#        uses: actions/checkout@v2
-#
-#      - name: Setup python 3.9
-#        uses: actions/setup-python@v2
-#        with:
-#          python-version: 3.9
-#
-#      - name: Publish to pypi
-#        uses: ./
-#        with:
-#          project-name: pypi-publish-with-poetry-dogfood
-#          pypi-token: ${{ secrets.PYPI_TOKEN_DOGFOOD }}
-#          pre-release: ${{ github.ref != 'refs/heads/main' }}
-#          dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
-#          pyproject-folder: ./pypi-publish-with-poetry-dogfood
+  dogfood-mac:
+    needs: dogfood-windows
+    runs-on: macos-11
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Publish to pypi
+        uses: ./
+        with:
+          project-name: pypi-publish-with-poetry-dogfood
+          pypi-token: ${{ secrets.PYPI_TOKEN_DOGFOOD }}
+          pre-release: ${{ github.ref != 'refs/heads/main' }}
+          dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
+          pyproject-folder: ./pypi-publish-with-poetry-dogfood

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
       id: get-minimum-version
       shell: bash
       working-directory: ${{ inputs.pyproject-folder }}
-      run: echo "::set-output name=minimum-version::$($GITHUB_ACTION_PATH/get-minimum-version.sh)"
+      run: echo "::set-output name=minimum-version::$(python $GITHUB_ACTION_PATH/get-minimum-version.py)"
 
     - name: Compute the release and prerelease versions
       id: get-versions

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
       id: get-minimum-version
       shell: bash
       working-directory: ${{ inputs.pyproject-folder }}
-      run: echo "::set-output name=minimum-version::$(${{ github.action_path }}get-minimum-version.sh)"
+      run: echo "::set-output name=minimum-version::$($GITHUB_ACTION_PATH/get-minimum-version.sh)"
 
     - name: Compute the release and prerelease versions
       id: get-versions

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,11 @@ inputs:
     description: The github tag prefix, such as `v` in `v3.4.2`
     default: v
     required: false
+  pyproject-folder:
+    description: The folder that contains the `pyproject.toml` file.
+    default: ./
+    required: false
+
 
 runs:
   using: 'composite'
@@ -45,8 +50,9 @@ runs:
       run: pipx install coveo-pypi-cli${{ inputs.pypi-cli-version }}
 
     - name: Determine the minimum version for this release (the one in the pyproject.toml file)
-      shell: bash
       id: get-minimum-version
+      shell: bash
+      working-directory: ${{ inputs.working-folder }}
       run: echo "::set-output name=minimum-version::$(${{ github.action_path }}/get-minimum-version.sh)"
 
     - name: Compute the release and prerelease versions
@@ -71,6 +77,7 @@ runs:
         fi
 
     - name: Setup poetry for publish
+      working-directory: ${{ inputs.working-folder }}
       shell: bash
       run: |
         poetry version ${{ steps.get-next-version.outputs.version }}
@@ -78,6 +85,7 @@ runs:
         poetry config pypi-token.pypi ${{ inputs.pypi-token }}
 
     - name: Publish to pypi.org
+      working-directory: ${{ inputs.working-folder }}
       shell: bash
       run: |
         if [[ ${{ inputs.dry-run }} == false ]]; then

--- a/action.yml
+++ b/action.yml
@@ -52,8 +52,8 @@ runs:
     - name: Determine the minimum version for this release (the one in the pyproject.toml file)
       id: get-minimum-version
       shell: bash
-      working-directory: ${{ inputs.working-folder }}
-      run: echo "::set-output name=minimum-version::$(${{ github.action_path }}/get-minimum-version.sh)"
+      working-directory: ${{ inputs.pyproject-folder }}
+      run: echo "::set-output name=minimum-version::$(${{ github.action_path }}get-minimum-version.sh)"
 
     - name: Compute the release and prerelease versions
       id: get-versions
@@ -77,7 +77,7 @@ runs:
         fi
 
     - name: Setup poetry for publish
-      working-directory: ${{ inputs.working-folder }}
+      working-directory: ${{ inputs.pyproject-folder }}
       shell: bash
       run: |
         poetry version ${{ steps.get-next-version.outputs.version }}
@@ -85,7 +85,7 @@ runs:
         poetry config pypi-token.pypi ${{ inputs.pypi-token }}
 
     - name: Publish to pypi.org
-      working-directory: ${{ inputs.working-folder }}
+      working-directory: ${{ inputs.pyproject-folder }}
       shell: bash
       run: |
         if [[ ${{ inputs.dry-run }} == false ]]; then

--- a/get-minimum-version.py
+++ b/get-minimum-version.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+from subprocess import check_output
+
+
+if __name__ == "__main__":
+    if not Path('pyproject.toml').exists():
+        raise Exception(f"Cannot find a `pyproject.toml` file in the current folder: {Path().resolve()}")
+
+    project_name, version = check_output(("poetry", "version")).strip().decode().split(' ')
+    print(version)

--- a/get-minimum-version.sh
+++ b/get-minimum-version.sh
@@ -1,4 +1,0 @@
-set -e
-PROJECT_NAME_AND_VERSION=$(poetry version)
-VERSION_ONLY=$(echo "$PROJECT_NAME_AND_VERSION" | cut --fields 2 --delimiter ' ')
-echo "$VERSION_ONLY"

--- a/pypi-publish-with-poetry-dogfood/README.md
+++ b/pypi-publish-with-poetry-dogfood/README.md
@@ -1,0 +1,3 @@
+This package is used to validate the functionality of the "coveooss/pypi-publish-with-poetry" GitHub action.
+
+You can read more about the action [here](https://github.com/coveooss/pypi-publish-with-poetry).

--- a/pypi-publish-with-poetry-dogfood/poetry.lock
+++ b/pypi-publish-with-poetry-dogfood/poetry.lock
@@ -1,0 +1,8 @@
+package = []
+
+[metadata]
+lock-version = "1.1"
+python-versions = ">=3.8"
+content-hash = "dedbcc8ad01960ccbef8502c70bda77771c2826a438e1e94ef27a36c71acd91a"
+
+[metadata.files]

--- a/pypi-publish-with-poetry-dogfood/pyproject.toml
+++ b/pypi-publish-with-poetry-dogfood/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "pypi-publish-with-poetry-dogfood"
+version = "0.1.0"
+description = "Empty package to test the GitHub Action `coveooss/pypi-publish-with-poetry`"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/coveooss/pypi-publish-with-poetry"
+authors = ["Jonathan Piché <tools@coveo.com>"]
+
+
+[tool.poetry.dependencies]
+python = ">=3.8"
+
+
+[build-system]
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
this implements the "eat your own dogfood" best practice. Using `./` as the action will execute the `action.yml` from the current changeset.

On PRs, a dry run will be done.
On a merge to main, we will publish a dummy package to pypi.org.

We can also publish a prerelease of the dummy package by launching the workflow manually on a branch.

Also, added an option for projects where the `pyproject.toml` is not at the root. And made sure to use it in the test!