### PR TITLE
fix publish chain and explain versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-dogfood-to-pypi:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Publish to pypi
+        uses: ./
+        with:
+          project-name: pypi-publish-with-poetry-dogfood
+          pypi-token: ${{ secrets.PYPI_TOKEN_DOGFOOD }}
+          pyproject-folder: ./pypi-publish-with-poetry-dogfood

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,23 +1,19 @@
 name: test-release
 
 on:
-  push:
-    branches:
-      - main
-
   pull_request:
     types: [opened, synchronize, reopened]
 
   workflow_dispatch:
     inputs:
-      deploy_branch:
-        description: The main branch is always deployed. To deploy from another branch, input something in the box below.
+      publish:
+        description: Select the host's OS for the real publish operation ('linux', 'windows', 'mac')
         required: false
-        default: ''
+        default: 'dry-run'
 
 
 jobs:
-  dogfood-linux:
+  publish-from-linux:
     runs-on: ubuntu-20.04
 
     steps:
@@ -35,11 +31,11 @@ jobs:
           project-name: pypi-publish-with-poetry-dogfood
           pypi-token: ${{ secrets.PYPI_TOKEN_DOGFOOD }}
           pre-release: ${{ github.ref != 'refs/heads/main' }}
-          dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
+          dry-run: ${{ github.event.inputs.publish != 'linux' }}
+          tag-prefix: dogfood-linux-
           pyproject-folder: ./pypi-publish-with-poetry-dogfood
 
-  dogfood-windows:
-    needs: dogfood-linux
+  publish-from-windows:
     runs-on: windows-2022
 
     steps:
@@ -57,11 +53,11 @@ jobs:
           project-name: pypi-publish-with-poetry-dogfood
           pypi-token: ${{ secrets.PYPI_TOKEN_DOGFOOD }}
           pre-release: ${{ github.ref != 'refs/heads/main' }}
-          dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
+          dry-run: ${{ github.event.inputs.publish != 'windows' }}
+          tag-prefix: dogfood-windows-
           pyproject-folder: ./pypi-publish-with-poetry-dogfood
 
-  dogfood-mac:
-    needs: dogfood-windows
+  publish-from-mac:
     runs-on: macos-11
 
     steps:
@@ -79,5 +75,6 @@ jobs:
           project-name: pypi-publish-with-poetry-dogfood
           pypi-token: ${{ secrets.PYPI_TOKEN_DOGFOOD }}
           pre-release: ${{ github.ref != 'refs/heads/main' }}
-          dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
+          dry-run: ${{ github.event.inputs.publish != 'mac' }}
+          tag-prefix: dogfood-mac-
           pyproject-folder: ./pypi-publish-with-poetry-dogfood

--- a/README.md
+++ b/README.md
@@ -29,6 +29,31 @@ Some limitations exist by design:
 Note: The packages `pip`, `setuptools`, `wheel` and `pipx` will be installed/upgraded 
 using the `python` executable from the path.
 
+# Default usage
+
+The default usage requires a project name and a token:
+
+      - name: Publish to pypi
+        uses: coveooss/pypi-publish-with-poetry@v1.0.0
+        with:
+          project-name: my-project-name
+          pypi-token: ${{ secrets.PYPI_TOKEN }}
+
+The project will be published, your changeset will be tagged with a `v1.2.3` kind of tag and revisions will increase automatically.
+
+## About the action's version
+
+In this repository, no tags are mutable by design.
+In other words, we don't keep a `@v1` or `latest` tag that we update as new revisions are released.
+
+Instead, we leverage our own repository tagging feature to provide users with a `v{major}.{minor}.{revision}` tag.
+This is similar to specifying the changeset's sha, but offers more visibility on the evolution of the action
+and allows us to transparently issue security and emergency hotfixes if that ever becomes a necessity.
+
+- If you want guaranteed immutability, specify a `@sha`.
+- If you want general immutability and potential hotfixes, specify a `v{major}.{minor}.{revision}`.
+- If you want to live dangerously, specify `@main`.
+
 
 # Documentation
 
@@ -126,9 +151,13 @@ You can launch a dry run of the publish operation, which will:
 The dry run option is detailed at  [the top of the action file](./action.yml).
 
 
-# Usage
+# Recommended usage
 
-This is how we recommend using this action. 
+The recommended usage will provide you this behavior:
+
+- Running the action from the main branch will automatically publish a new version.
+- Running the action from other branches will produce a dry run.
+- Running the action manually on a branch and typing in "true" when prompted will publish a prerelease version.
 
 First, you need to add some inputs in the workflow dispatch: 
 
@@ -143,7 +172,7 @@ First, you need to add some inputs in the workflow dispatch:
 Here's how we suggest you design the `uses` step:
     
       - name: Publish to pypi
-        uses: coveooss/pypi-publish-with-poetry@v1
+        uses: coveooss/pypi-publish-with-poetry@v1.0.0
         with:
           project-name: my-project-name
           pypi-token: ${{ secrets.PYPI_TOKEN }}
@@ -151,18 +180,12 @@ Here's how we suggest you design the `uses` step:
           dry-run: ${{ github.ref != 'refs/heads/main' && github.event.inputs.publish != 'true' }}
 
 
-So that:
-
-- Running the action from the main branch will automatically publish a new version.
-- Running the action from other branches will produce a dry run.
-- Running the action manually on a branch and typing in "true" when prompted will publish a prerelease version.
-
-The options are described in details at [the top of the action file](./action.yml).
+More options are described at [the top of the action file](./action.yml).
 
 
 # How to start a new project
 
-When starting a new project, we recommend setting the version to `0.1.0` as the first official public release, 
+When starting a new project, we recommend setting your project's version to `0.1.0` as the first official public release, 
 as described in the [semantic versioning FAQ](https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase).
 
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,11 @@ inputs:
     default: v
     required: false
 
+  disable-repository-tags:
+    description: Set to `true` in order to disable the automatic tagging feature.
+    default: 'false'
+    required: false
+
   pyproject-folder:
     description: The folder that contains the `pyproject.toml` file.
     default: ./
@@ -120,7 +125,7 @@ runs:
       env:
         TAG_NAME: ${{ steps.get-next-tag.outputs.tag-name }}
       run: |
-        if [[ ${{ inputs.dry-run }} == false ]]; then
+        if [[ ${{ inputs.dry-run }} == false && ${{ inputs.disable-repository-tags }} != true ]]; then
           git push origin $TAG_NAME
         else
           echo "If this wasn't a dry run, I would push this new tag named $TAG_NAME"

--- a/action.yml
+++ b/action.yml
@@ -2,35 +2,45 @@ name: publish-to-pypi
 description: Publish a poetry project to pypi.org. Requires "python" to be in the path.
 
 inputs:
+  # required inputs
   project-name:
     description: The project name in pypi.org
     required: true
+
   pypi-token:
     description: The pypi token to use for authentication
     required: true
+
+  # behavior and options
   pre-release:
     description: Set to true if a pre-release version should be published.
     required: false
     default: "false"
+
   dry-run:
     description: Set to true for a test run that doesn't publish or tag.
     default: "false"
     required: false
-  poetry-version:
-    description: The version of poetry to use.
-    default: ==1.1.8
-    required: false
-  pypi-cli-version:
-    description: The version of coveo-pypi-cli to use.
-    default: ==2.0.3
-    required: false
+
   tag-prefix:
     description: The github tag prefix, such as `v` in `v3.4.2`
     default: v
     required: false
+
   pyproject-folder:
     description: The folder that contains the `pyproject.toml` file.
     default: ./
+    required: false
+
+  # internal
+  poetry-version:
+    description: The version of poetry to use.
+    default: ==1.1.8
+    required: false
+
+  pypi-cli-version:
+    description: The version of coveo-pypi-cli to use.
+    default: ==2.0.3
     required: false
 
 


### PR DESCRIPTION
`pypi.org` takes a while to index newly updated packages, so my idea of chaining the linux-windows-mac releases (so we'd get e.g. 0.0.1, 0.0.2, 0.0.3) doesn't work. When the package isn't showing, we try overwriting the previous one and it fails.

Instead, I separated the PR/manual action and the "merge to main" action and adjusted the former so that we can dry run them all or select one OS that does the real publish.

Also, I found it annoying to have to update tags around, and since we already have a version/tag system in place I thought we should just use it. So I documented how this repository will be versioned going forward.

bonus: it runs in parallel now, and each OS is a check, instead of the 3 being a sequence of a single check 😎 